### PR TITLE
Adding a blog component

### DIFF
--- a/packages/blog/__fixtures__/blog.js
+++ b/packages/blog/__fixtures__/blog.js
@@ -1,0 +1,27 @@
+import Blog from '..';
+
+export default {
+  component: Blog,
+  props: {
+    posts: [
+      {
+        title: 'Returning to campus',
+        _createdAt: '2018-09-28T08:11:14Z',
+        body: ['Line one', 'line two', 'line three'],
+        author: 'Alan Reader',
+        slug: 'returning-to-campus',
+        categories: [
+          {
+            title: 'AFES'
+          },
+          {
+            title: 'Supporters'
+          },
+          {
+            title: 'Uni Fellowship'
+          }
+        ]
+      }
+    ]
+  }
+};

--- a/packages/blog/blog.js
+++ b/packages/blog/blog.js
@@ -1,0 +1,54 @@
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import Post from './post';
+
+class Blog extends Component {
+  render() {
+    return (
+      <>
+        {this.props.posts
+          .filter(post => {
+            if (
+              this.props.category &&
+              Object.keys(this.props.category).length !== 0
+            ) {
+              return post.categories
+                .map(a => a.title)
+                .includes(this.props.category);
+            }
+            return post;
+          })
+          .sort((a, b) => {
+            return (
+              new Date(a._createdAt).getTime() -
+              new Date(b._createdAt).getTime()
+            );
+          })
+          .reverse()
+          .map(post => (
+            <Post
+              key={post.title}
+              title={post.title}
+              date={post._createdAt}
+              categories={post.categories}
+              body={post.body}
+            />
+          ))}
+      </>
+    );
+  }
+}
+
+export default Blog;
+
+Blog.propTypes = {
+  posts: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string.isRequired,
+      _createdAt: PropTypes.string.isRequired,
+      body: PropTypes.string,
+      categories: PropTypes.string.isRequired
+    })
+  ).isRequired,
+  category: PropTypes.objectOf(PropTypes.string).isRequired
+};

--- a/packages/blog/blog.js
+++ b/packages/blog/blog.js
@@ -30,8 +30,11 @@ class Blog extends Component {
               key={post.title}
               title={post.title}
               date={post._createdAt}
+              dateFormat={this.props.dateFormat}
               categories={post.categories}
               body={post.body}
+              renderContent={this.props.renderContent}
+              linkComponent={this.props.linkComponent}
             />
           ))}
       </>
@@ -50,5 +53,13 @@ Blog.propTypes = {
       categories: PropTypes.string.isRequired
     })
   ).isRequired,
-  category: PropTypes.objectOf(PropTypes.string).isRequired
+  category: PropTypes.objectOf(PropTypes.string).isRequired,
+  linkComponent: PropTypes.func.isRequired,
+  renderContent: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
+    .isRequired,
+  dateFormat: PropTypes.string
+};
+
+Blog.defaultProps = {
+  dateFormat: 'dddd, MMMM do YYYY'
 };

--- a/packages/blog/example-link.js
+++ b/packages/blog/example-link.js
@@ -1,0 +1,29 @@
+/* This is an example link component which will need to
+be amended for the specific use case/dependencies required*/
+import React from 'react';
+import PropTypes from 'prop-types';
+import RouterLink from 'react-router-dom/Link';
+// Or your preferred Link component from NextJS etc.
+import MineralLink from 'mineral-ui/Link';
+
+const Link = props => (
+  <MineralLink
+    element={RouterLink}
+    to={{
+      pathname: '/blog',
+      search: `?category=${props.title}`
+    }}
+  >
+    {props.title}
+  </MineralLink>
+);
+
+Link.propTypes = {
+  title: PropTypes.string
+};
+
+Link.defaultProps = {
+  title: undefined
+};
+
+export default Link;

--- a/packages/blog/index.js
+++ b/packages/blog/index.js
@@ -1,0 +1,3 @@
+import Blog from './blog';
+
+export default Blog;

--- a/packages/blog/package.json
+++ b/packages/blog/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@newfrontdoor/blog",
+  "version": "0.1.0",
+  "dependencies": {
+    "prop-types": "^15.6.0",
+    "date-fns": "^1.29.0"
+  },
+  "peerDependencies": {
+    "emotion": "^9.0",
+    "mineral-ui": "^0.48.0",
+    "react": "^16.0",
+    "react-emotion": "^9.0"
+  },
+  "xo": false
+}

--- a/packages/blog/post.js
+++ b/packages/blog/post.js
@@ -1,0 +1,98 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled, {css} from 'react-emotion';
+import Text from 'mineral-ui/Text';
+import {Link} from 'react-router-dom';
+import format from 'date-fns/format';
+import SanityBlock from './SanityBlock'; // Or replace with some other block renderer
+
+const ContentWrapper = styled('div')`
+  display: flex;
+  flex-flow: row wrap;
+  margin: auto;
+  width: 100vw;
+  max-width: 920px;
+  padding-top: 40px;
+  @media (min-width: 420px) {
+    min-height: 600px;
+  }
+`;
+
+const Meta = styled('div')`
+  flex: 1 0 auto;
+  height: auto;
+  overflow: hidden;
+  width: 250px;
+  padding: 20px;
+  position: sticky;
+  top: 40px;
+  height: 50px;
+  background: inherit;
+  @media (min-width: 420px) {
+    top: 110px;
+    height: 150px;
+  }
+`;
+
+const Content = styled('div')`
+  flex: 1 0 auto;
+  width: auto;
+  max-width: 24em;
+  @media (min-width: 420px) {
+    max-width: 32em;
+    padding-top: 23.5px;
+  }
+`;
+
+const Post = props => (
+  <ContentWrapper display="flex">
+    <Meta>
+      <Text element="h2">{props.title}</Text>
+      <Text appearance="mouse">
+        {format(new Date(props.date), 'dddd, MMMM do YYYY')}
+      </Text>
+      <Text
+        className={css`
+          display: none;
+          @media (min-width: 420px) {
+            display: block;
+          }
+        `}
+        element="div"
+        appearance="mouse"
+      >
+        <ul>
+          {props.categories.map(category => (
+            <li key={category.title + props.date}>
+              <Link
+                to={{
+                  pathname: '/blog',
+                  search: `?category=${category.title}`
+                }}
+              >
+                {category.title}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </Text>
+    </Meta>
+    <Content>
+      <SanityBlock blocks={props.body} />
+    </Content>
+  </ContentWrapper>
+);
+
+export default Post;
+
+Post.propTypes = {
+  title: PropTypes.string.isRequired,
+  date: PropTypes.string.isRequired,
+  body: PropTypes.string.isRequired,
+  categories: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string.isRequired,
+      date: PropTypes.string.isRequired
+    })
+  ).isRequired
+};

--- a/packages/blog/post.js
+++ b/packages/blog/post.js
@@ -2,9 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled, {css} from 'react-emotion';
 import Text from 'mineral-ui/Text';
-import {Link} from 'react-router-dom';
 import format from 'date-fns/format';
-import SanityBlock from './SanityBlock'; // Or replace with some other block renderer
 
 const ContentWrapper = styled('div')`
   display: flex;
@@ -44,55 +42,52 @@ const Content = styled('div')`
   }
 `;
 
-const Post = props => (
-  <ContentWrapper display="flex">
-    <Meta>
-      <Text element="h2">{props.title}</Text>
-      <Text appearance="mouse">
-        {format(new Date(props.date), 'dddd, MMMM do YYYY')}
-      </Text>
-      <Text
-        className={css`
-          display: none;
-          @media (min-width: 420px) {
-            display: block;
-          }
-        `}
-        element="div"
-        appearance="mouse"
-      >
-        <ul>
-          {props.categories.map(category => (
-            <li key={category.title + props.date}>
-              <Link
-                to={{
-                  pathname: '/blog',
-                  search: `?category=${category.title}`
-                }}
-              >
-                {category.title}
-              </Link>
-            </li>
-          ))}
-        </ul>
-      </Text>
-    </Meta>
-    <Content>
-      <SanityBlock blocks={props.body} />
-    </Content>
-  </ContentWrapper>
-);
+const Post = props => {
+  const {linkComponent: Link} = props;
+  return (
+    <ContentWrapper display="flex">
+      <Meta>
+        <Text element="h2">{props.title}</Text>
+        <Text appearance="mouse">
+          {format(new Date(props.date), props.dateFormat)}
+        </Text>
+        <Text
+          className={css`
+            display: none;
+            @media (min-width: 420px) {
+              display: block;
+            }
+          `}
+          element="div"
+          appearance="mouse"
+        >
+          <ul>
+            {props.categories.map(category => (
+              <li key={category.title + props.date}>
+                <Link {...category} />
+              </li>
+            ))}
+          </ul>
+        </Text>
+      </Meta>
+      <Content>{props.renderContent(props.body)}</Content>
+    </ContentWrapper>
+  );
+};
 
 export default Post;
 
 Post.propTypes = {
   title: PropTypes.string.isRequired,
-  date: PropTypes.string.isRequired,
+  date: PropTypes.instanceOf(Date).isRequired,
+  dateFormat: PropTypes.string.isRequired,
   body: PropTypes.string.isRequired,
   categories: PropTypes.arrayOf(
     PropTypes.shape({
       title: PropTypes.string.isRequired,
       date: PropTypes.string.isRequired
     })
-  ).isRequired
+  ).isRequired,
+  renderContent: PropTypes.func.isRequired,
+  linkComponent: PropTypes.func.isRequired
 };

--- a/packages/blog/readme.md
+++ b/packages/blog/readme.md
@@ -1,0 +1,50 @@
+A blog component
+
+Contains:
+- Basic flexbox layout with sticky title/meta content
+- categories render as links which then filter content
+- blogs provided as array of blog objects to the blog.js
+  file, which then render in the post.js file individually
+- Date object format can be passed in on props.dateFormat or
+ can just use the default props 'dddd, MMMM do YYYY'
+ - Mobile view
+ - example link file for passing in from containing component,
+ currently using react router, but can be amended for use case
+
+ Example use with react-router-dom and Sanity block renderer:
+`
+import React, {Component} from 'react';
+import {BrowserRouter, Route, Switch} from 'react-router-dom';
+import SanityBlock from './components/SanityBlock';
+import Link from './components/link';
+const queryString = require('query-string');
+
+class App extends Component {
+    render() {
+    return (
+      <BrowserRouter>
+        <div className={body}>
+            <Switch>
+                <Route
+                    exact
+                    path={process.env.PUBLIC_URL + '/blog'}
+                    render={({location}) => (
+                    <Blog
+                        category={queryString.parse(location.search).category}
+                        posts={this.props.posts}
+                        renderContent={body => {
+                        return <SanityBlock blocks={body} />;
+                        }}
+                        linkComponent={Link}
+                    />
+                    )}
+                />
+            </Switch>
+        </div>
+      </BrowserRouter>
+    );
+  }
+}
+
+export default App;
+`

--- a/packages/blog/readme.md
+++ b/packages/blog/readme.md
@@ -12,7 +12,7 @@ Contains:
  currently using react router, but can be amended for use case
 
  Example use with react-router-dom and Sanity block renderer:
-`
+```
 import React, {Component} from 'react';
 import {BrowserRouter, Route, Switch} from 'react-router-dom';
 import SanityBlock from './components/SanityBlock';
@@ -47,4 +47,4 @@ class App extends Component {
 }
 
 export default App;
-`
+```


### PR DESCRIPTION
A blog component. Currently requires react-router-dom for links for the categories, and references 'SanityBlock' a custom component that wraps Sanity's block-content-to-react component, designed to render block-level content.

Not exactly sure how to adjust the component to be more suitable for our UI, but amending SanityBlock to something that renders KeystoneJS block content would help.